### PR TITLE
Improve notice messaging and update survival package documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: SummaryTables
 Title: Publication-Ready Summary Tables for Jamovi
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: 
     person("Nour Edin", "Darwish", , "nouredindarwish@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0009-5527-4539"))

--- a/NOTES.md
+++ b/NOTES.md
@@ -20,3 +20,7 @@
       - title: Tarone-Ware
         name: tarone
 ```
+
+## Non-syntactic names in survfit
+
+The `survival` package version 3.8-7 now supports non-syntactic names. In the future, I need to deprecate the usage of `make.names` and instead use the actual column names. This might require a modified version of `validateVarNames`—for instance, I might only need to check for backslashes (`\\`), or perhaps no manual checks will be needed at all. I will implement and validate this once jamovi updates its bundled version of the `survival` package.

--- a/R/notices.R
+++ b/R/notices.R
@@ -27,6 +27,7 @@ runSafe <- function(expr, collector) {
     expr,
     warning = function(w) {
       msg <- w$message
+      msg <- gsub("were returned during :", "occurred:", msg, fixed = TRUE)
       if (!grepl("C:/Rtools/home/builder", msg, fixed = TRUE)) {
         collector$warnings <- c(collector$warnings, trimws(msg))
       }
@@ -34,6 +35,7 @@ runSafe <- function(expr, collector) {
     },
     message = function(m) {
       msg <- m$message
+      msg <- gsub("were returned during :", "occurred:", msg, fixed = TRUE)
       collector$messages <- c(collector$messages, trimws(msg))
       invokeRestart("muffleMessage")
     }
@@ -55,7 +57,7 @@ runSafe <- function(expr, collector) {
 displayNotices <- function(collector, options, results) {
   # Messages (INFO) — stat test feedback from cards
   if (length(collector$messages) > 0) {
-    msgContent <- paste(collector$messages, collapse = "\n")
+    msgContent <- paste(collector$messages, collapse = "\n\n")
 
     msgNotice <- jmvcore::Notice$new(
       options = options,
@@ -68,7 +70,7 @@ displayNotices <- function(collector, options, results) {
 
   # Warnings (WARNING) — direct R warnings
   if (length(collector$warnings) > 0) {
-    warnContent <- paste(collector$warnings, collapse = "\n")
+    warnContent <- paste(collector$warnings, collapse = "\n\n")
 
     warnNotice <- jmvcore::Notice$new(
       options = options,

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -1,12 +1,12 @@
 ---
 title: Publication-Ready Summary Tables
 name: SummaryTables
-version: 1.0.0
+version: 1.0.1
 jms: '1.0'
 authors:
   - Nour Edin Darwish
 maintainer: Nour Edin Darwish <nouredindarwish@gmail.com>
-date: '2026-04-11'
+date: '2026-04-23'
 type: R
 description: >-
   A comprehensive module for creating publication-ready summary and regression


### PR DESCRIPTION
This pull request is a minor update focused on improving the handling and display of messages and warnings, as well as updating documentation and metadata for the `SummaryTables` package. The changes enhance the clarity of notices shown to users and prepare for future compatibility with updates in dependencies.

Improvements to message and warning handling:

* Updated the formatting of collected messages and warnings in `displayNotices` by separating entries with double newlines for better readability. [[1]](diffhunk://#diff-c8eccbc18f7a9f562b8c57aff85d5110bd1636a67bbd8dd79c3510a38b9cb41dL58-R60) [[2]](diffhunk://#diff-c8eccbc18f7a9f562b8c57aff85d5110bd1636a67bbd8dd79c3510a38b9cb41dL71-R73)
* Standardized warning and message text by replacing "were returned during :" with "occurred:" in `runSafe`, making the output clearer.

Documentation and metadata updates:

* Added a note about upcoming changes related to non-syntactic names in the `survival` package, indicating future plans for compatibility.
* Bumped the package version from 1.0.0 to 1.0.1 in both `DESCRIPTION` and `jamovi/0000.yaml`, and updated the release date. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL4-R4) [[2]](diffhunk://#diff-8e5b8cae256a69f859f54b1ce3b600ede16a57c1af6be59f0a0d73039c854818L4-R9)